### PR TITLE
Better CLI argv file detection

### DIFF
--- a/src/assets/js/script.js
+++ b/src/assets/js/script.js
@@ -59,8 +59,12 @@ function setupRendererBehaviour()
 function loadFromArguments()
 {
     let args = remote.getGlobal("arguments");
-    if(args.length > 1){
-        loadFile(args[1]);
+    const hasFile = args.filter((file) => {
+        const ext = file.split('.').pop();
+        return supportedExtensions.includes(ext.toUpperCase());
+    });
+    if(hasFile.length > 0){
+        loadFile(hasFile[0]);
     }
 }
 


### PR DESCRIPTION
A simple change in the file detection passed by `global.arguments` to make sure the file is detected no matter the arguments.
I do understand the project is old but still works and does the job

___

Note: As this includes an old version of electron, it includes the `sandbox` bug, the `.desktop` file still needs to be edited and pass the `--no-sandbox` argument but other than that it's still a program that can easily be integrated on linux 

```
# /usr/share/applications/meshviewer.desktop
Exec="/opt/Mesh Viewer/meshviewer" --no-sandbox %U
```